### PR TITLE
Pack bytes for int64 properly

### DIFF
--- a/src/Bytes.sol
+++ b/src/Bytes.sol
@@ -24,9 +24,11 @@ library Bytes {
 
     // Converts an int64 to its 8 byte representation.
     function toBytes(int64 self) internal pure returns (bytes memory bts) {
+        int64 data = self << (256 - 64);
+
         bts = new bytes(8);
         assembly {
-            mstore(add(bts, 32), self)
+            mstore(add(bts, 32), data)
         }
     }
 


### PR DESCRIPTION
Prior you would just get the upper portion of the 256 bit underlying value. This seems to do the trick correctly when printing out the results from rust:

When attempting to encrypt a signed 1240:

```
Signed bytes: [0, 0, 0, 0, 0, 0, 4, 216]
Encrypting Signed { val: 1240 } with public data [43, 62, 20, 150, 0, 0, 0, 1]
```

and when attempting to encrypt -1345:

```
Signed bytes: [255, 255, 255, 255, 255, 255, 250, 191]
Encrypting Signed { val: -1345 } with public data [43, 62, 20, 150, 0, 0, 0, 1]
```