### PR TITLE
Decrypt primitive

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  FOUNDRY_REV: 1e02b444205cd87602a54ea094b80e7d4c6c462e
+  FOUNDRY_REV: c6045ce4eac63901921a8ab6a80d1583dd8e4c04
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,8 @@ jobs:
           cargo install \
             --git https://github.com/Sunscreen-tech/foundry \
             --rev ${{ env.FOUNDRY_REV }} \
-            --profile local forge
+            --profile local forge \
+            --locked
 
       - name: Save new forge binary
         if: steps.cache.outputs.cache-hit != 'true'

--- a/src/Bytes.sol
+++ b/src/Bytes.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.8.19;
 
-import "forge-std/console.sol";
-
 library Bytes {
 
     /*************************************************************************

--- a/src/Bytes.sol
+++ b/src/Bytes.sol
@@ -1,16 +1,17 @@
 pragma solidity ^0.8.19;
 
 library Bytes {
-
-    /*************************************************************************
+    /**
+     *
      * Types to bytes memory conversions
-     *************************************************************************/
+     *
+     */
 
     /**
      * Copies 'len' bytes from 'self' into a new 'bytes memory', starting at index '0'.
      * Returns the newly created 'bytes memory'
      * The returned bytes will be of length 'len'.
-     */ 
+     */
     function toBytes(bytes32 self, uint8 len) internal pure returns (bytes memory bts) {
         require(len <= 32);
         bts = new bytes(len);
@@ -22,7 +23,7 @@ library Bytes {
         }
     }
 
-    /** 
+    /**
      * Copies 'self' into a new 'bytes memory'.
      *
      * Requires that:
@@ -34,7 +35,7 @@ library Bytes {
      * @param bitsize The number of bits to copy from 'self'.
      * @return bts The bytes representation of the uint256 value. The bytes will
      *             be of length 'bitsize / 8'.
-     */ 
+     */
     function toBytes(uint256 self, uint16 bitsize) internal pure returns (bytes memory bts) {
         require(8 <= bitsize && bitsize <= 256 && bitsize % 8 == 0);
         self <<= 256 - bitsize;
@@ -43,7 +44,7 @@ library Bytes {
 
     /**
      * Copies 'self' into a new 'bytes memory'.
-     * 
+     *
      * @param self The uint256 value to convert.
      * @return bts The bytes representation of the uint256 value. The bytes will
      *             be of length 32.
@@ -72,7 +73,7 @@ library Bytes {
      * @param self The bytes8 value to convert.
      * @return bts The bytes representation of the bytes8 value. The bytes
      *             will be of length 8.
-     */ 
+     */
     function toBytes(bytes8 self) internal pure returns (bytes memory bts) {
         bts = new bytes(8);
         assembly {
@@ -80,9 +81,11 @@ library Bytes {
         }
     }
 
-    /*************************************************************************
+    /**
+     *
      * Bytes memory to types conversions
-     *************************************************************************/
+     *
+     */
 
     /**
      * Converts a bytes array to a uint256 value.

--- a/src/Bytes.sol
+++ b/src/Bytes.sol
@@ -1,9 +1,18 @@
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
+
+import "forge-std/console.sol";
 
 library Bytes {
-    // Copies 'len' bytes from 'self' into a new 'bytes memory', starting at index '0'.
-    // Returns the newly created 'bytes memory'
-    // The returned bytes will be of length 'len'.
+
+    /*************************************************************************
+     * Types to bytes memory conversions
+     *************************************************************************/
+
+    /**
+     * Copies 'len' bytes from 'self' into a new 'bytes memory', starting at index '0'.
+     * Returns the newly created 'bytes memory'
+     * The returned bytes will be of length 'len'.
+     */ 
     function toBytes(bytes32 self, uint8 len) internal pure returns (bytes memory bts) {
         require(len <= 32);
         bts = new bytes(len);
@@ -15,14 +24,42 @@ library Bytes {
         }
     }
 
-    // Copies 'self' into a new 'bytes memory'.
-    // Returns the newly created 'bytes memory'
-    // The returned bytes will be of length '32'.
+    /** 
+     * Copies 'self' into a new 'bytes memory'.
+     *
+     * Requires that:
+     *  - '8 <= bitsize <= 256'
+     *  - 'bitsize % 8 == 0'
+     * The returned bytes will be of length 'bitsize / 8'.
+     *
+     * @param self The uint256 value to convert.
+     * @param bitsize The number of bits to copy from 'self'.
+     * @return bts The bytes representation of the uint256 value. The bytes will
+     *             be of length 'bitsize / 8'.
+     */ 
+    function toBytes(uint256 self, uint16 bitsize) internal pure returns (bytes memory bts) {
+        require(8 <= bitsize && bitsize <= 256 && bitsize % 8 == 0);
+        self <<= 256 - bitsize;
+        bts = toBytes(bytes32(self), uint8(bitsize / 8));
+    }
+
+    /**
+     * Copies 'self' into a new 'bytes memory'.
+     * 
+     * @param self The uint256 value to convert.
+     * @return bts The bytes representation of the uint256 value. The bytes will
+     *             be of length 32.
+     */
     function toBytes(uint256 self) internal pure returns (bytes memory bts) {
         bts = toBytes(bytes32(self), 32);
     }
 
-    // Converts an int64 to its 8 byte representation.
+    /**
+     * Converts an int64 value to bytes.
+     * @param self The int64 value to convert.
+     * @return bts The bytes representation of the int64 value. The bytes
+     *             will be of length 8.
+     */
     function toBytes(int64 self) internal pure returns (bytes memory bts) {
         int64 data = self << (256 - 64);
 
@@ -32,7 +69,12 @@ library Bytes {
         }
     }
 
-    // Converts a bytes8 to its 8 byte representation.
+    /**
+     * Converts a bytes8 to its 8 bytes memory representation.
+     * @param self The bytes8 value to convert.
+     * @return bts The bytes representation of the bytes8 value. The bytes
+     *             will be of length 8.
+     */ 
     function toBytes(bytes8 self) internal pure returns (bytes memory bts) {
         bts = new bytes(8);
         assembly {
@@ -40,15 +82,62 @@ library Bytes {
         }
     }
 
-    // Copies 'self' into a new 'bytes memory'.
-    // Returns the newly created 'bytes memory'
-    // Requires that:
-    //  - '8 <= bitsize <= 256'
-    //  - 'bitsize % 8 == 0'
-    // The returned bytes will be of length 'bitsize / 8'.
-    function toBytes(uint256 self, uint16 bitsize) internal pure returns (bytes memory bts) {
-        require(8 <= bitsize && bitsize <= 256 && bitsize % 8 == 0);
-        self <<= 256 - bitsize;
-        bts = toBytes(bytes32(self), uint8(bitsize / 8));
+    /*************************************************************************
+     * Bytes memory to types conversions
+     *************************************************************************/
+
+    /**
+     * Converts a bytes array to a uint256 value.
+     *
+     * @param self The bytes array to convert. Must be 32 bytes long.
+     * @return result The uint256 value represented by the bytes array.
+     */
+    function fromBytesUint256(bytes memory self) internal pure returns (uint256) {
+        require(self.length == 32);
+
+        return uint256(bytes32(self));
+    }
+
+    /**
+     * Converts a byte array to an unsigned 64-bit integer.
+     *
+     * @param self The input byte array. Must be 8 bytes long.
+     * @return result The converted unsigned 64-bit integer.
+     */
+    function fromBytesUint64(bytes memory self) internal pure returns (uint64) {
+        require(self.length == 8);
+
+        return uint64(bytes8(self));
+    }
+
+    /**
+     * Converts a byte array to a signed 64-bit integer.
+     *
+     * @param self The input byte array. Must be 8 bytes long.
+     * @return result The converted signed 64-bit integer.
+     */
+    function fromBytesInt64(bytes memory self) internal pure returns (int64) {
+        // Not sure why this works but it is implied by this post:
+        // https://ethereum.stackexchange.com/a/112263
+        //
+        // Attempting to perform an mload like in the Frac64 case causes the
+        // interpreted value to be zero.
+        require(self.length == 8);
+        return int64(uint64(bytes8(self)));
+    }
+
+    /**
+     * Converts a byte array to a 64 bit floating point value, big endian encoded.
+     *
+     * @param self The input byte array. Must be 8 bytes long.
+     * @return result The converted floating 64-bit value.
+     */
+    function fromBytesFrac64(bytes memory self) internal pure returns (bytes8) {
+        require(self.length == 8);
+        bytes8 out;
+        assembly {
+            out := mload(add(self, 32))
+        }
+        return out;
     }
 }

--- a/src/FHE.sol
+++ b/src/FHE.sol
@@ -73,7 +73,6 @@ contract FHE {
     uint256 public constant DECRYPT_UINT256_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_UINT256_NAMESPACE | FHE_DECRYPT_ADDRESS;
 
-
     // uint64
     uint256 public constant ADD_CIPHERUINT64CIPHERUINT64_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_ADDRESS_UINT64_NAMESPACE | FHE_ADDRESS_ADD_NAMESPACE | 0x00;
@@ -172,7 +171,6 @@ contract FHE {
      * Packing variants
      *
      */
-
 
     /// Pack values for a binary operation on two encrypted values
     /// @param pubk Bincode encoded `Sunscreen::PublicKey`
@@ -521,7 +519,7 @@ contract FHE {
                     0 // retSize
                 )
             let size := returndatasize()
-            
+
             // Get a pointer to some free space in memory. This information is
             // always located at 0x40. See
             // https://blog.trustlook.com/understand-evm-bytecode-part-4/
@@ -529,8 +527,8 @@ contract FHE {
 
             // Update the free memory pointer to point to the next free memory
             // slot.
-            mstore(0x40, add(output, add(0x20, size))) 
-            
+            mstore(0x40, add(output, add(0x20, size)))
+
             // Dynamic bytes store their size in the first 32 bytes of the data,
             // so we need to copy that over.
             mstore(output, size)

--- a/src/FHE.sol
+++ b/src/FHE.sol
@@ -544,24 +544,6 @@ contract FHE {
         return output;
     }
 
-            // let size := returndatasize()
-            // output := mload(0x40)
-            // mstore(output, 0x1F)
-            // mstore(add(output, 0x20), size)
-            // returndatacopy(add(output, 0x40), 0, size)
-            // if iszero(res) {
-            //     revert(output, add(0x20, size))
-            // }
-
-            // let size := returndatasize()
-            // let p := mload(0x40)
-            // mstore(p, 0x20)
-            // mstore(add(p, 0x20), size)
-            // returndatacopy(add(p, 0x40), 0, size)
-            // switch res
-            // case 0 { revert(p, add(0x40, size)) }
-            // default { return(p, add(0x40, size)) }
-
     /// Call a binary operation on two encrypted values
     /// @param _address The address of the precompile.
     /// @param gasCost How much gas it costs to run this precompile.

--- a/src/FHE.sol
+++ b/src/FHE.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "./Bytes.sol";
 
@@ -17,6 +17,7 @@ contract FHE {
     uint256 public constant MULTIPLY_PLAIN_GAS = ADD_PLAIN_GAS;
     uint256 public constant ENCRYPT_GAS = 1000;
     uint256 public constant REENCRYPT_GAS = 2000;
+    uint256 public constant DECRYPT_GAS = 1000;
     uint256 public constant NETWORK_PUBLIC_KEY_GAS = 0;
 
     // Precompile addresses
@@ -36,6 +37,7 @@ contract FHE {
     uint256 public constant FHE_NETWORK_KEY_ADDRESS = 0x00_00_00_00;
     uint256 public constant FHE_ENCRYPT_ADDRESS = 0x00_00_00_10;
     uint256 public constant FHE_REENCRYPT_ADDRESS = 0x00_00_00_20;
+    uint256 public constant FHE_DECRYPT_ADDRESS = 0x00_00_00_30;
 
     uint256 public constant FHE_NETWORK_PUBLIC_KEY_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_NETWORK_KEY_ADDRESS;
@@ -68,6 +70,10 @@ contract FHE {
     uint256 public constant REENCRYPT_UINT256_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_UINT256_NAMESPACE | FHE_REENCRYPT_ADDRESS;
 
+    uint256 public constant DECRYPT_UINT256_ADDRESS =
+        FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_UINT256_NAMESPACE | FHE_DECRYPT_ADDRESS;
+
+
     // uint64
     uint256 public constant ADD_CIPHERUINT64CIPHERUINT64_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_ADDRESS_UINT64_NAMESPACE | FHE_ADDRESS_ADD_NAMESPACE | 0x00;
@@ -95,6 +101,9 @@ contract FHE {
 
     uint256 public constant REENCRYPT_UINT64_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_UINT64_NAMESPACE | FHE_REENCRYPT_ADDRESS;
+
+    uint256 public constant DECRYPT_UINT64_ADDRESS =
+        FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_UINT64_NAMESPACE | FHE_DECRYPT_ADDRESS;
 
     // int64
     uint256 public constant ADD_CIPHERINT64CIPHERINT64_ADDRESS =
@@ -124,6 +133,9 @@ contract FHE {
     uint256 public constant REENCRYPT_INT64_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_INT64_NAMESPACE | FHE_REENCRYPT_ADDRESS;
 
+    uint256 public constant DECRYPT_INT64_ADDRESS =
+        FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_INT64_NAMESPACE | FHE_DECRYPT_ADDRESS;
+
     // frac64
     uint256 public constant ADD_CIPHERFRAC64CIPHERFRAC64_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_ADDRESS_FRAC64_NAMESPACE | FHE_ADDRESS_ADD_NAMESPACE | 0x00;
@@ -152,11 +164,15 @@ contract FHE {
     uint256 public constant REENCRYPT_FRAC64_ADDRESS =
         FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_FRAC64_NAMESPACE | FHE_REENCRYPT_ADDRESS;
 
+    uint256 public constant DECRYPT_FRAC64_ADDRESS =
+        FHE_ADDRESS_NAMESPACE | FHE_NETWORK_API_NAMESPACE | FHE_ADDRESS_FRAC64_NAMESPACE | FHE_DECRYPT_ADDRESS;
+
     /**
      *
      * Packing variants
      *
      */
+
 
     /// Pack values for a binary operation on two encrypted values
     /// @param pubk Bincode encoded `Sunscreen::PublicKey`
@@ -319,7 +335,7 @@ contract FHE {
         uint256 offset_1 = 8 + offsetLength;
         require(offset_1 <= type(uint32).max, "pubk argument too large");
 
-        bytes memory byteEncodedValue = plaintextValue.toBytes(8);
+        bytes memory byteEncodedValue = plaintextValue.toBytes(64);
         bytes memory offset_1be = offset_1.toBytes(32);
 
         input = bytes.concat(offset_1be, byteEncodedValue, data);
@@ -485,6 +501,9 @@ contract FHE {
         view
         returns (bytes memory)
     {
+        bytes memory output;
+        bool success;
+
         assembly {
             // 32 bytes at the start of input hold its length, hence
             // 1. we add 32 to point to the start of the actual input data
@@ -492,7 +511,7 @@ contract FHE {
 
             // EVM precompile contract addresses listed here: https://www.evm.codes/precompiled?fork=merge
             // See https://www.evm.codes/#fa?fork=merge for staticcall details
-            let res :=
+            success :=
                 staticcall(
                     gasCost,
                     _address,
@@ -502,15 +521,46 @@ contract FHE {
                     0 // retSize
                 )
             let size := returndatasize()
-            let p := mload(0x40)
-            mstore(p, 0x20)
-            mstore(add(p, 0x20), size)
-            returndatacopy(add(p, 0x40), 0, size)
-            switch res
-            case 0 { revert(p, add(0x40, size)) }
-            default { return(p, add(0x40, size)) }
+            
+            // Get a pointer to some free space in memory. This information is
+            // always located at 0x40. See
+            // https://blog.trustlook.com/understand-evm-bytecode-part-4/
+            output := mload(0x40) // Get the free memory pointer
+
+            // Update the free memory pointer to point to the next free memory
+            // slot.
+            mstore(0x40, add(output, add(0x20, size))) 
+            
+            // Dynamic bytes store their size in the first 32 bytes of the data,
+            // so we need to copy that over.
+            mstore(output, size)
+
+            // Copy the data from the return data to the output, starting at the
+            // address of the output + 32 bytes (to skip the size)
+            returndatacopy(add(output, 0x20), 0, size)
         }
+
+        require(success, "Precompile call failed");
+        return output;
     }
+
+            // let size := returndatasize()
+            // output := mload(0x40)
+            // mstore(output, 0x1F)
+            // mstore(add(output, 0x20), size)
+            // returndatacopy(add(output, 0x40), 0, size)
+            // if iszero(res) {
+            //     revert(output, add(0x20, size))
+            // }
+
+            // let size := returndatasize()
+            // let p := mload(0x40)
+            // mstore(p, 0x20)
+            // mstore(add(p, 0x20), size)
+            // returndatacopy(add(p, 0x40), 0, size)
+            // switch res
+            // case 0 { revert(p, add(0x40, size)) }
+            // default { return(p, add(0x40, size)) }
 
     /// Call a binary operation on two encrypted values
     /// @param _address The address of the precompile.
@@ -861,6 +911,15 @@ contract FHE {
         return reencryptUint256(pubk, encryptedValue);
     }
 
+    /// Decrypts an encrypted uint256 value.
+    ///
+    /// @param encryptedValue The encrypted value to be decrypted.
+    /// @return result The decrypted uint256 value.
+    function decryptUint256(bytes memory encryptedValue) public view returns (uint256 result) {
+        bytes memory output = callPrecompile(DECRYPT_UINT256_ADDRESS, DECRYPT_GAS, encryptedValue);
+        result = output.fromBytesUint256();
+    }
+
     /**
      *
      * uint64 operations
@@ -1031,6 +1090,15 @@ contract FHE {
     function refreshUint64(bytes memory encryptedValue) public view returns (bytes memory) {
         bytes memory pubk = networkPublicKey();
         return reencryptUint64(pubk, encryptedValue);
+    }
+
+    /// Decrypts an encrypted uint64 value.
+    ///
+    /// @param encryptedValue The encrypted value to be decrypted.
+    /// @return result The decrypted uint64 value.
+    function decryptUint64(bytes memory encryptedValue) public view returns (uint64) {
+        bytes memory output = callPrecompile(DECRYPT_UINT64_ADDRESS, DECRYPT_GAS, encryptedValue);
+        return output.fromBytesUint64();
     }
 
     /**
@@ -1205,6 +1273,15 @@ contract FHE {
         return reencryptInt64(pubk, encryptedValue);
     }
 
+    /// Decrypts an encrypted int64 value.
+    ///
+    /// @param encryptedValue The encrypted value to be decrypted.
+    /// @return result The decrypted int64 value.
+    function decryptInt64(bytes memory encryptedValue) public view returns (int64) {
+        bytes memory output = callPrecompile(DECRYPT_INT64_ADDRESS, DECRYPT_GAS, encryptedValue);
+        return output.fromBytesInt64();
+    }
+
     /**
      *
      * frac64 operations
@@ -1377,6 +1454,17 @@ contract FHE {
         return reencryptFrac64(pubk, encryptedValue);
     }
 
+    /// Decrypts an encrypted frac64 value.
+    ///
+    /// @param encryptedValue The encrypted value to be decrypted.
+    /// @return result The decrypted frac64 value.
+    function decryptFrac64(bytes memory encryptedValue) public view returns (bytes8) {
+        bytes memory output = callPrecompile(DECRYPT_FRAC64_ADDRESS, DECRYPT_GAS, encryptedValue);
+        return output.fromBytesFrac64();
+    }
+
+    /// Returns the public key of the network.
+    /// @return bytes The public key of the network.
     function networkPublicKey() public view returns (bytes memory) {
         return callPrecompile(FHE_NETWORK_PUBLIC_KEY_ADDRESS, NETWORK_PUBLIC_KEY_GAS, "");
     }

--- a/test/Bytes.t.sol
+++ b/test/Bytes.t.sol
@@ -10,8 +10,7 @@ contract FHETest is Test {
     bytes8 public constant frac64_5 = 0x40_14_00_00_00_00_00_00;
     bytes8 public constant frac64_4 = 0x40_10_00_00_00_00_00_00;
 
-    function setUp() public {
-    }
+    function setUp() public {}
 
     function testBytesToUint256() public {
         uint256 value1 = 5;
@@ -24,7 +23,6 @@ contract FHETest is Test {
         uint256 out2 = bts2.fromBytesUint256();
         assertEq(out2, value2);
     }
-
 
     function testBytesToUint64() public {
         uint64 value = 4129075;
@@ -46,5 +44,4 @@ contract FHETest is Test {
         bytes8 out = bts.fromBytesFrac64();
         assertEq(out, value);
     }
-
 }

--- a/test/Bytes.t.sol
+++ b/test/Bytes.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
 import "../src/Bytes.sol";

--- a/test/Bytes.t.sol
+++ b/test/Bytes.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../src/Bytes.sol";
+
+contract FHETest is Test {
+    using Bytes for *;
+
+    bytes8 public constant frac64_5 = 0x40_14_00_00_00_00_00_00;
+    bytes8 public constant frac64_4 = 0x40_10_00_00_00_00_00_00;
+
+    function setUp() public {
+    }
+
+    function testBytesToUint256() public {
+        uint256 value1 = 5;
+        bytes memory bts1 = value1.toBytes();
+        uint256 out1 = bts1.fromBytesUint256();
+        assertEq(out1, value1);
+
+        uint256 value2 = 4129075;
+        bytes memory bts2 = value2.toBytes();
+        uint256 out2 = bts2.fromBytesUint256();
+        assertEq(out2, value2);
+    }
+
+
+    function testBytesToUint64() public {
+        uint64 value = 4129075;
+        bytes memory bts = value.toBytes(64);
+        uint64 out = bts.fromBytesUint64();
+        assertEq(out, value);
+    }
+
+    function testBytesToInt64() public {
+        int64 value = -4129075;
+        bytes memory bts = value.toBytes();
+        int64 out = bts.fromBytesInt64();
+        assertEq(out, value);
+    }
+
+    function testBytesToFrac64() public {
+        bytes8 value = frac64_5;
+        bytes memory bts = value.toBytes();
+        bytes8 out = bts.fromBytesFrac64();
+        assertEq(out, value);
+    }
+
+}

--- a/test/FHE.t.sol
+++ b/test/FHE.t.sol
@@ -391,27 +391,27 @@ contract FHETest is Test {
     }
 
     // Currently cause an internal SEAL error
-    // function testMultiplyInt64EncPlain() public {
-    //     vm.pauseGasMetering();
-    //     bytes memory pubk = vm.readFileBinary("test/data/public_key.pub");
-    //     bytes memory a_enc = vm.readFileBinary("test/data/a_i64.bin");
-    //     int64 b = 4;
+    function testMultiplyInt64EncPlain() public {
+        vm.pauseGasMetering();
+        bytes memory pubk = vm.readFileBinary("test/data/public_key.pub");
+        bytes memory a_enc = vm.readFileBinary("test/data/a_i64.bin");
+        int64 b = 4;
 
-    //     bytes memory c_enc = fhe.multiplyInt64EncPlain(pubk, a_enc, b);
-    //     assert(c_enc.length > 0);
-    //     vm.resumeGasMetering();
-    // }
+        bytes memory c_enc = fhe.multiplyInt64EncPlain(pubk, a_enc, b);
+        assert(c_enc.length > 0);
+        vm.resumeGasMetering();
+    }
 
-    // function testMultiplyInt64PlainEnc() public {
-    //     vm.pauseGasMetering();
-    //     bytes memory pubk = vm.readFileBinary("test/data/public_key.pub");
-    //     int64 a = 5;
-    //     bytes memory b_enc = vm.readFileBinary("test/data/b_i64.bin");
+    function testMultiplyInt64PlainEnc() public {
+        vm.pauseGasMetering();
+        bytes memory pubk = vm.readFileBinary("test/data/public_key.pub");
+        int64 a = 5;
+        bytes memory b_enc = vm.readFileBinary("test/data/b_i64.bin");
 
-    //     bytes memory c_enc = fhe.multiplyInt64PlainEnc(pubk, a, b_enc);
-    //     assert(c_enc.length > 0);
-    //     vm.resumeGasMetering();
-    // }
+        bytes memory c_enc = fhe.multiplyInt64PlainEnc(pubk, a, b_enc);
+        assert(c_enc.length > 0);
+        vm.resumeGasMetering();
+    }
 
     function testEncryptInt64() public {
         vm.pauseGasMetering();

--- a/test/FHE.t.sol
+++ b/test/FHE.t.sol
@@ -290,7 +290,7 @@ contract FHETest is Test {
 
         assert(c_enc_2.length > 0);
         assertEq(c, value);
-        
+
         vm.resumeGasMetering();
     }
 

--- a/test/FHE.t.sol
+++ b/test/FHE.t.sol
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
+import "forge-std/console.sol";
 import "../src/FHE.sol";
 
 contract FHETest is Test {
     FHE public fhe;
 
-    bytes8 public constant frac64_5 = 0x40_14_00_00_00_00_00_00;
+    bytes8 public constant frac64_1 = 0x3F_F0_00_00_00_00_00_00;
     bytes8 public constant frac64_4 = 0x40_10_00_00_00_00_00_00;
+    bytes8 public constant frac64_5 = 0x40_14_00_00_00_00_00_00;
+
+    bytes8 public constant frac64_9 = 0x40_22_00_00_00_00_00_00;
+    bytes8 public constant frac64_20 = 0x40_34_00_00_00_00_00_00;
 
     function setUp() public {
         fhe = new FHE();
@@ -38,10 +43,7 @@ contract FHETest is Test {
 
     function testNetworkPublicKey() public {
         vm.pauseGasMetering();
-        bytes memory c_enc = fhe.networkPublicKey();
-        bytes memory c_enc_2 = fhe.refreshUint256(c_enc);
-
-        assert(c_enc_2.length > 0);
+        fhe.networkPublicKey();
         vm.resumeGasMetering();
     }
 
@@ -59,6 +61,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addUint256EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network + b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint256(a_network);
+        bytes memory b_enc_network = fhe.encryptUint256(b_network);
+        bytes memory c_enc_network = fhe.addUint256EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -70,6 +85,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addUint256EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network + b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint256(a_network);
+        bytes memory c_enc_network = fhe.addUint256EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -81,6 +108,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addUint256PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network + b_network;
+
+        bytes memory b_enc_network = fhe.encryptUint256(b_network);
+        bytes memory c_enc_network = fhe.addUint256PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -92,6 +131,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractUint256EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network - b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint256(a_network);
+        bytes memory b_enc_network = fhe.encryptUint256(b_network);
+        bytes memory c_enc_network = fhe.subtractUint256EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -103,6 +155,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractUint256EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network - b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint256(a_network);
+        bytes memory c_enc_network = fhe.subtractUint256EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -114,6 +178,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractUint256PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network - b_network;
+
+        bytes memory b_enc_network = fhe.encryptUint256(b_network);
+        bytes memory c_enc_network = fhe.subtractUint256PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -125,6 +201,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyUint256EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network * b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint256(a_network);
+        bytes memory b_enc_network = fhe.encryptUint256(b_network);
+        bytes memory c_enc_network = fhe.multiplyUint256EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -136,6 +225,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyUint256EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network * b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint256(a_network);
+        bytes memory c_enc_network = fhe.multiplyUint256EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -147,6 +248,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyUint256PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint256 a_network = 5290240597;
+        uint256 b_network = 478698;
+        uint256 c_network = a_network * b_network;
+
+        bytes memory b_enc_network = fhe.encryptUint256(b_network);
+        bytes memory c_enc_network = fhe.multiplyUint256PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        uint256 c_network_decrypted = fhe.decryptUint256(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -169,10 +282,25 @@ contract FHETest is Test {
 
     function testRefreshUint256() public {
         vm.pauseGasMetering();
-        bytes memory c_enc = fhe.encryptUint256(5);
+        uint256 value = 6912345;
+        bytes memory c_enc = fhe.encryptUint256(value);
         bytes memory c_enc_2 = fhe.refreshUint256(c_enc);
 
+        uint256 c = fhe.decryptUint256(c_enc_2);
+
         assert(c_enc_2.length > 0);
+        assertEq(c, value);
+        
+        vm.resumeGasMetering();
+    }
+
+    function testDecryptUint256() public {
+        vm.pauseGasMetering();
+        uint256 value = 745819;
+        bytes memory c_enc = fhe.encryptUint256(value);
+        uint256 c = fhe.decryptUint256(c_enc);
+
+        assertEq(c, value);
         vm.resumeGasMetering();
     }
 
@@ -190,6 +318,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addUint64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network + b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint64(a_network);
+        bytes memory b_enc_network = fhe.encryptUint64(b_network);
+        bytes memory c_enc_network = fhe.addUint64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -201,6 +342,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addUint64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network + b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint64(a_network);
+        bytes memory c_enc_network = fhe.addUint64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -212,6 +365,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addUint64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network + b_network;
+
+        bytes memory b_enc_network = fhe.encryptUint64(b_network);
+        bytes memory c_enc_network = fhe.addUint64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -223,6 +388,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractUint64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network - b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint64(a_network);
+        bytes memory b_enc_network = fhe.encryptUint64(b_network);
+        bytes memory c_enc_network = fhe.subtractUint64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -234,6 +412,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractUint64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network - b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint64(a_network);
+        bytes memory c_enc_network = fhe.subtractUint64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -245,6 +435,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractUint64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network - b_network;
+
+        bytes memory b_enc_network = fhe.encryptUint64(b_network);
+        bytes memory c_enc_network = fhe.subtractUint64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -256,6 +458,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyUint64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network * b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint64(a_network);
+        bytes memory b_enc_network = fhe.encryptUint64(b_network);
+        bytes memory c_enc_network = fhe.multiplyUint64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -267,6 +482,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyUint64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network * b_network;
+
+        bytes memory a_enc_network = fhe.encryptUint64(a_network);
+        bytes memory c_enc_network = fhe.multiplyUint64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -278,6 +505,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyUint64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        uint64 a_network = 5290240597;
+        uint64 b_network = 478698;
+        uint64 c_network = a_network * b_network;
+
+        bytes memory b_enc_network = fhe.encryptUint64(b_network);
+        bytes memory c_enc_network = fhe.multiplyUint64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        uint64 c_network_decrypted = fhe.decryptUint64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -300,10 +539,25 @@ contract FHETest is Test {
 
     function testRefreshUint64() public {
         vm.pauseGasMetering();
-        bytes memory c_enc = fhe.encryptUint64(5);
+        uint64 value = 6912345;
+        bytes memory c_enc = fhe.encryptUint64(value);
         bytes memory c_enc_2 = fhe.refreshUint64(c_enc);
 
+        uint64 c = fhe.decryptUint64(c_enc_2);
+
         assert(c_enc_2.length > 0);
+        assertEq(c, value);
+
+        vm.resumeGasMetering();
+    }
+
+    function testDecryptUint64() public {
+        vm.pauseGasMetering();
+        uint64 value = 745819;
+        bytes memory c_enc = fhe.encryptUint64(value);
+        uint64 c = fhe.decryptUint64(c_enc);
+
+        assertEq(c, value);
         vm.resumeGasMetering();
     }
 
@@ -321,6 +575,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addInt64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network + b_network;
+
+        bytes memory a_enc_network = fhe.encryptInt64(a_network);
+        bytes memory b_enc_network = fhe.encryptInt64(b_network);
+        bytes memory c_enc_network = fhe.addInt64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -332,6 +599,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addInt64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network + b_network;
+
+        bytes memory a_enc_network = fhe.encryptInt64(a_network);
+        bytes memory c_enc_network = fhe.addInt64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -343,6 +622,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addInt64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network + b_network;
+
+        bytes memory b_enc_network = fhe.encryptInt64(b_network);
+        bytes memory c_enc_network = fhe.addInt64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -354,6 +645,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractInt64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network - b_network;
+
+        bytes memory a_enc_network = fhe.encryptInt64(a_network);
+        bytes memory b_enc_network = fhe.encryptInt64(b_network);
+        bytes memory c_enc_network = fhe.subtractInt64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -365,6 +669,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractInt64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network - b_network;
+
+        bytes memory a_enc_network = fhe.encryptInt64(a_network);
+        bytes memory c_enc_network = fhe.subtractInt64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -376,6 +692,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractInt64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network - b_network;
+
+        bytes memory b_enc_network = fhe.encryptInt64(b_network);
+        bytes memory c_enc_network = fhe.subtractInt64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -387,6 +715,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyInt64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network * b_network;
+
+        bytes memory a_enc_network = fhe.encryptInt64(a_network);
+        bytes memory b_enc_network = fhe.encryptInt64(b_network);
+        bytes memory c_enc_network = fhe.multiplyInt64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -399,6 +740,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyInt64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network * b_network;
+
+        bytes memory a_enc_network = fhe.encryptInt64(a_network);
+        bytes memory c_enc_network = fhe.multiplyInt64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -410,6 +763,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyInt64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        int64 a_network = -5290240597;
+        int64 b_network = 478698;
+        int64 c_network = a_network * b_network;
+
+        bytes memory b_enc_network = fhe.encryptInt64(b_network);
+        bytes memory c_enc_network = fhe.multiplyInt64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        int64 c_network_decrypted = fhe.decryptInt64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -432,10 +797,25 @@ contract FHETest is Test {
 
     function testRefreshInt64() public {
         vm.pauseGasMetering();
-        bytes memory c_enc = fhe.encryptInt64(5);
+        int64 value = -6912345;
+        bytes memory c_enc = fhe.encryptInt64(value);
         bytes memory c_enc_2 = fhe.refreshInt64(c_enc);
 
+        int64 c = fhe.decryptInt64(c_enc_2);
+
         assert(c_enc_2.length > 0);
+        assertEq(c, value);
+
+        vm.resumeGasMetering();
+    }
+
+    function testDecryptInt64() public {
+        vm.pauseGasMetering();
+        int64 value = 745819;
+        bytes memory c_enc = fhe.encryptInt64(value);
+        int64 c = fhe.decryptInt64(c_enc);
+
+        assertEq(c, value);
         vm.resumeGasMetering();
     }
 
@@ -453,6 +833,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addFrac64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_9;
+
+        bytes memory a_enc_network = fhe.encryptFrac64(a_network);
+        bytes memory b_enc_network = fhe.encryptFrac64(b_network);
+        bytes memory c_enc_network = fhe.addFrac64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -464,6 +857,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addFrac64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_9;
+
+        bytes memory a_enc_network = fhe.encryptFrac64(a_network);
+        bytes memory c_enc_network = fhe.addFrac64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -475,6 +880,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.addFrac64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_9;
+
+        bytes memory b_enc_network = fhe.encryptFrac64(b_network);
+        bytes memory c_enc_network = fhe.addFrac64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -486,6 +903,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractFrac64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_1;
+
+        bytes memory a_enc_network = fhe.encryptFrac64(a_network);
+        bytes memory b_enc_network = fhe.encryptFrac64(b_network);
+        bytes memory c_enc_network = fhe.subtractFrac64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -497,6 +927,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractFrac64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_1;
+
+        bytes memory a_enc_network = fhe.encryptFrac64(a_network);
+        bytes memory c_enc_network = fhe.subtractFrac64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -508,6 +950,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.subtractFrac64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_1;
+
+        bytes memory b_enc_network = fhe.encryptFrac64(b_network);
+        bytes memory c_enc_network = fhe.subtractFrac64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -519,6 +973,19 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyFrac64EncEnc(pubk, a_enc, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_20;
+
+        bytes memory a_enc_network = fhe.encryptFrac64(a_network);
+        bytes memory b_enc_network = fhe.encryptFrac64(b_network);
+        bytes memory c_enc_network = fhe.multiplyFrac64EncEnc(fhe.networkPublicKey(), a_enc_network, b_enc_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -530,6 +997,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyFrac64EncPlain(pubk, a_enc, b);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_20;
+
+        bytes memory a_enc_network = fhe.encryptFrac64(a_network);
+        bytes memory c_enc_network = fhe.multiplyFrac64EncPlain(fhe.networkPublicKey(), a_enc_network, b_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -541,6 +1020,18 @@ contract FHETest is Test {
 
         bytes memory c_enc = fhe.multiplyFrac64PlainEnc(pubk, a, b_enc);
         assert(c_enc.length > 0);
+
+        // Check that our operation returns the correct value.
+        bytes8 a_network = frac64_5;
+        bytes8 b_network = frac64_4;
+        bytes8 c_network = frac64_20;
+
+        bytes memory b_enc_network = fhe.encryptFrac64(b_network);
+        bytes memory c_enc_network = fhe.multiplyFrac64PlainEnc(fhe.networkPublicKey(), a_network, b_enc_network);
+
+        bytes8 c_network_decrypted = fhe.decryptFrac64(c_enc_network);
+        assertEq(c_network, c_network_decrypted);
+
         vm.resumeGasMetering();
     }
 
@@ -563,10 +1054,25 @@ contract FHETest is Test {
 
     function testRefreshFrac64() public {
         vm.pauseGasMetering();
-        bytes memory c_enc = fhe.encryptFrac64(frac64_5);
+        bytes8 value = frac64_20;
+        bytes memory c_enc = fhe.encryptFrac64(value);
         bytes memory c_enc_2 = fhe.refreshFrac64(c_enc);
 
+        bytes8 c = fhe.decryptFrac64(c_enc_2);
+
         assert(c_enc_2.length > 0);
+        assertEq(c, value);
+
+        vm.resumeGasMetering();
+    }
+
+    function testDecryptFrac64() public {
+        vm.pauseGasMetering();
+        bytes8 value = frac64_5;
+        bytes memory c_enc = fhe.encryptFrac64(value);
+        bytes8 c = fhe.decryptFrac64(c_enc);
+
+        assertEq(c, value);
         vm.resumeGasMetering();
     }
 }


### PR DESCRIPTION
Adds a decrypt precompile and updates the tests to ensure that any FHE operation on a network key produces the correct value.

This also fixes an issue with `callPrecompile`: the `return` EVM opcode returns from the contract context, not the function. This was leading to the unreachable code warnings (which were correct). We now return using the solidity standard return. Note that when returning a dynamic bytes array, the free pointer at memory location `0x40` in the EVM needs to be updated.